### PR TITLE
Parse mda opt task

### DIFF
--- a/franklab_mountainsort/core.py
+++ b/franklab_mountainsort/core.py
@@ -316,7 +316,7 @@ def get_mda_files_dataframe(data_path, recursive=False):
 
 def _get_mda_file_information(mda_file):
     mda_re = re.compile(
-        "^(?:(\d*)_)(?:(\w*)_)(\d*)(?:_(\w*)){0,1}(?:\.[a-zA-Z]*(\d*)){0,1}\.\w*$"
+        "^(?:(\d*)_)(?:(\w*)_)(\d*)(?:_(\w*)){0,1}(?:\.[a-zA-Z]*(\d*))\.\w*$"
     )
     try:
         match_re = mda_re.match(os.path.basename(mda_file))

--- a/franklab_mountainsort/core.py
+++ b/franklab_mountainsort/core.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pprint
+import re
 
 import franklab_mountainsort.ms4_franklab_pyplines as pyp
 import numpy as np
@@ -313,18 +314,17 @@ def get_mda_files_dataframe(data_path, recursive=False):
             .join(geom_df)
             .replace(dict(geom_filepath={np.nan: None})))
 
-
 def _get_mda_file_information(mda_file):
+    mda_re = re.compile(
+        "^(?:(\d*)_)(?:(\w*)_)(\d*)(?:_(\w*)){0,1}(?:\.[a-zA-Z]*(\d*)){0,1}\.\w*$"
+    )
     try:
-        date, animal, epoch, other = os.path.basename(mda_file).split('_')
-        date, epoch = int(date), int(epoch)
-        task, electrode_name, _ = other.split('.')
-        electrode_number = int(electrode_name.strip('nt'))
-
+        match_re = mda_re.match(os.path.basename(mda_file))
+        date, animal, epoch, task, electrode_number = match_re.groups()
+        date, epoch, electrode_number = int(date), int(epoch), int(electrode_number)
         return animal, date, epoch, electrode_number, task, mda_file
-    except ValueError:
+    except (ValueError, AttributeError):
         pass
-
 
 def get_geom_files_dataframe(data_path, recursive=False):
     '''

--- a/franklab_mountainsort/ms4_franklab_proc2py.py
+++ b/franklab_mountainsort/ms4_franklab_proc2py.py
@@ -348,7 +348,7 @@ def tagged_curation(cluster_metrics, metrics_tagged,
     )
 
 
-def get_mda_list(date, ntrode, data_location):
+def get_mda_list(animal, date, ntrode, data_location):
     '''
 
     Parameters
@@ -364,9 +364,7 @@ def get_mda_list(date, ntrode, data_location):
     '''
     date = str(date)
     mda_list = glob.glob(
-        os.path.join(data_location, date, '*', f'*.nt{ntrode}.mda'))
-    mda_list = [file for file in mda_list
-                if len(os.path.basename(file).split('_')) == 4]
+        os.path.join(data_location, date, '*.mda', f'{date}_{animal}_*.nt{ntrode}.mda'))
     mda_list.sort()
 
     return mda_list
@@ -377,7 +375,7 @@ def get_epoch_offsets(dataset_dir, opts=None):
     Parameters
     ----------
     dataset_dir : str
-    opts : None or dict, optional
+    opts : None or dict, optional*
 
     Returns
     -------

--- a/franklab_mountainsort/ms4_franklab_proc2py.py
+++ b/franklab_mountainsort/ms4_franklab_proc2py.py
@@ -375,7 +375,7 @@ def get_epoch_offsets(dataset_dir, opts=None):
     Parameters
     ----------
     dataset_dir : str
-    opts : None or dict, optional*
+    opts : None or dict, optional
 
     Returns
     -------

--- a/franklab_mountainsort/ms4_franklab_pyplines.py
+++ b/franklab_mountainsort/ms4_franklab_pyplines.py
@@ -79,7 +79,7 @@ def concat_epochs(dataset_dir, mda_list=None, opts=None, mda_opts=None):
             f'...Finding list of mda files from mda directories of '
             f'date: {mda_opts["date"]}, ntrode: {mda_opts["ntrode"]}')
         mda_list = get_mda_list(
-            mda_opts['date'], mda_opts['ntrode'], mda_opts['data_location'])
+            mda_opts['anim'], mda_opts['date'], mda_opts['ntrode'], mda_opts['data_location'])
         str_start = [f'timeseries_list:{entry}' for entry in mda_list]
     elif isinstance(mda_list, str):
         logger.info('...Using mda files listed in prv file')

--- a/franklab_mountainsort/ms4_franklab_pyplines.py
+++ b/franklab_mountainsort/ms4_franklab_pyplines.py
@@ -230,7 +230,7 @@ def ms4_sort_on_segs(dataset_dir, output_dir, geom=None,
             'Finding list of mda file from mda directories of '
             f'date:{mda_opts["date"]}, ntrode:{mda_opts["ntrode"]}')
         mda_list = get_mda_list(
-            mda_opts['date'], mda_opts['ntrode'], mda_opts['data_location'])
+            mda_opts['anim'], mda_opts['date'], mda_opts['ntrode'], mda_opts['data_location'])
         # calculate time_offsets and total_duration
         sample_offsets, total_samples = get_epoch_offsets(
             dataset_dir=dataset_dir, opts={'mda_list': mda_list})


### PR DESCRIPTION
the task field in the filename is supposed to be optional but was required by the previous _get_mda_file_information in order to return the dataframe of mda file components. This pull request solves this for cases tested below. The function now returns None in place of an empty optional field. Are there other filename conventions that it doesn't account for? @edeno @acomrie 
Similarly, this PR allows valid filenames without task field to get past get_mda_list.

## Test cases run in a notebook
```
import re

filename_re = re.compile(^(?:(\d*)_)(?:(\w*)_)(\d*)(?:_(\w*)){0,1}(?:\.[a-zA-Z]*(\d*))\.\w*$")

filename_match = filename_re.match("20170428_JZ4_05_s3.nt3.mda")
print(f"groups = {filename_match.groups()}")
assert filename_match.groups() == ("20170428", "JZ4", "05", "s3", "3")

filename_match = filename_re.match("20170428_JZ4_05.nt3.mda")
print(f"groups = {filename_match.groups()}")
assert filename_match.groups() == ("20170428", "JZ4", "05", None, "3")
```
~~filename_re = re.compile(^(?:(\d*)_)(?:(\w*)_)(\d*)(?:_(\w*)){0,1}(?:\.[a-zA-Z]*(\d*)){0,1}\.\w*$")~~

~~filename_match = filename_re.match("20170428_JZ4_05_s3.mda")~~
~~print(f"groups = {filename_match.groups()}")~~
~~assert filename_match.groups() == ("20170428", "JZ4", "05", "s3", None)~~

~~filename_match = filename_re.match("20170428_JZ4_05.mda")~~
~~print(f"groups = {filename_match.groups()}")~~
~~assert filename_match.groups() == ("20170428", "JZ4", "05", None, None)~~
